### PR TITLE
First steps to allow styling

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -64,7 +64,7 @@ function div end
 
 node(::AbstractWidget) = nothing
 
-node(w::Widget) = w.node
+node(w::Widget) = w.scope !== nothing ? w.scope.dom : nothing
 
 function defaultlayout(ui::Widget)
     div(values(ui.children)..., ui.display)
@@ -74,3 +74,5 @@ function layout(w::Wiget, f)
     g = w.layout
     Widget(w, layout = x -> f(g(x)))
 end
+
+(w::Widget)(args...; kwargs...) = layout(w, t->t(args...; kwargs...))

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -62,8 +62,15 @@ end
 
 function div end
 
-function node end
+node(::AbstractWidget) = nothing
+
+node(w::Widget) = w.node
 
 function defaultlayout(ui::Widget)
     div(values(ui.children)..., ui.display)
+end
+
+function layout(w::Wiget, f)
+    g = w.layout
+    Widget(w, layout = x -> f(g(x)))
 end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -70,9 +70,9 @@ function defaultlayout(ui::Widget)
     div(values(ui.children)..., ui.display)
 end
 
-function layout(w::Widget, f)
+function layout(f, w::Widget)
     g = w.layout
     Widget(w, layout = x -> f(g(x)))
 end
 
-(w::Widget)(args...; kwargs...) = layout(w, t->t(args...; kwargs...))
+(w::Widget)(args...; kwargs...) = layout(t->t(args...; kwargs...), w)

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -70,7 +70,7 @@ function defaultlayout(ui::Widget)
     div(values(ui.children)..., ui.display)
 end
 
-function layout(w::Wiget, f)
+function layout(w::Widget, f)
     g = w.layout
     Widget(w, layout = x -> f(g(x)))
 end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -70,6 +70,22 @@ function defaultlayout(ui::Widget)
     div(values(ui.children)..., ui.display)
 end
 
+"""
+`layout(f, w::Widget)`
+
+Create a new `Widget` that is a copy of `w` and whose layout is the layout of `w` composed
+with the function `f`.
+
+## Examples
+
+```julia
+using InteractBase, CSSUtil, Widgets
+w = button("OK")
+Widgets.layout(w) do t
+    hbox("Click here", t)
+end
+```
+"""
 function layout(f, w::Widget)
     g = w.layout
     Widget(w, layout = x -> f(g(x)))

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -31,6 +31,8 @@ function Widget{T}(w::Widget; kwargs...) where {T}
     n
 end
 
+Widget(w::Widget{T}; kwargs...) where {T} = Widget{T}(w; kwargs...)
+
 widgettype(::Widget{T}) where {T} = T
 
 component(x, u) = getindex(x, u)

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -6,18 +6,20 @@ mutable struct Widget{T} <: AbstractWidget
     children::OrderedDict{Symbol, Any}
     output::Observable
     display::Observable
+    node
     scope
     update::Function
     layout::Function
     function Widget{T}(children = OrderedDict{Symbol, Any}();
         output = Observable{Any}(nothing),
         display = Observable{Any}(nothing),
+        node = nothing,
         scope = nothing,
         update = t -> (),
         layout = defaultlayout) where {T}
 
         child_dict = OrderedDict{Symbol, Any}(Symbol(key) => val for (key, val) in children)
-        new{T}(child_dict, output, display, scope, update, layout)
+        new{T}(child_dict, output, display, node, scope, update, layout)
     end
 end
 

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -6,20 +6,18 @@ mutable struct Widget{T} <: AbstractWidget
     children::OrderedDict{Symbol, Any}
     output::Observable
     display::Observable
-    node
     scope
     update::Function
     layout::Function
     function Widget{T}(children = OrderedDict{Symbol, Any}();
         output = Observable{Any}(nothing),
         display = Observable{Any}(nothing),
-        node = nothing,
         scope = nothing,
         update = t -> (),
         layout = defaultlayout) where {T}
 
         child_dict = OrderedDict{Symbol, Any}(Symbol(key) => val for (key, val) in children)
-        new{T}(child_dict, output, display, node, scope, update, layout)
+        new{T}(child_dict, output, display, scope, update, layout)
     end
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 InteractBase 0.5.0
+WebIO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Widgets, Observables, DataStructures, InteractBase
+using Widgets, Observables, DataStructures, InteractBase, WebIO
 using Widgets: Widget, @layout, @map, @map!, @on, widgettype
 @static if VERSION < v"0.7.0-DEV.2005"
     using Base.Test
@@ -109,4 +109,12 @@ end
     obs[] = Observable(11)
     sleep(0.1)
     @test o2[] == 11
+end
+
+@testset "layout" begin
+    wdg = slider(1:100)
+    wdg2 = wdg(style = Dict("color" => "red"))
+    n = WebIO.render(wdg2)
+    @test props(n)[:style]["color"] == "red"
+    @test Widgets.node(wdg) isa Node
 end


### PR DESCRIPTION
On two separate fronts:

On one side, this tries to define the primary node of a widget (each widget should define their own if they feel it applies). It is a reference to the node and should be modified in place.

On the other side, the non-in place tools to modify a `Widget` (say `n(style = ...)`  where `n::Node` can be used on the `layout` of the widget. With `wdg(style = ..)` at the time of rendering, the style will be applied to the resulting node.