### PR TITLE
type stability and time to first widget improvements

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -78,6 +78,3 @@ name2string(x::QuoteNode) = Expr(:call, :string, x)
 name2string(x::Expr) = name2string(x.args[end])
 
 isijulia() = isdefined(Main, :IJulia) && Main.IJulia.inited
-
-to_abstractobservable(s::AbstractObservable) = s
-to_abstractobservable(s) = Observable(s)

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -4,7 +4,7 @@ abstract type AbstractWidget{T, S} <: AbstractObservable{S}; end
 
 mutable struct Widget{T, S} <: AbstractWidget{T, S}
     components::OrderedDict{Symbol, Any}
-    output::AbstractObservable{S}
+    output::Observable{S}
     scope
     layout::Function
     function Widget{T}(components::OrderedDict{Symbol,Any}, output::Observable{S}, scope, layout) where {T,S}

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -26,9 +26,9 @@ Widget{T}(components; kwargs...) where {T} = Widget{T}(OrderedDict{Symbol, Any}(
 Widget{T}(; components = OrderedDict{Symbol, Any}(), kwargs...) where {T} = Widget{T}(components; kwargs...)
 
 function Widget{T}(w::Widget; 
-    components=w.components, output=w.output, scope=w.scope, layout=w.layout, kw...
+    components=w.components, output=w.output, scope=w.scope, layout=w.layout
 ) where {T}
-    Widget{T}(; components=components, output=output, scope=scope, layout=layout, kw...)
+    Widget{T}(; components=components, output=output, scope=scope, layout=layout)
 end
 
 Widget(w::Widget{T}; kwargs...) where {T} = Widget{T}(w; kwargs...)

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -7,26 +7,28 @@ mutable struct Widget{T, S} <: AbstractWidget{T, S}
     output::AbstractObservable{S}
     scope
     layout::Function
-    function Widget{T}(components::OrderedDict{Symbol, Any};
-        output = Observable{Any}(nothing),
-        scope = nothing,
-        layout = defaultlayout(get_backend())) where {T, S}
-
-        output_obs = to_abstractobservable(output)
-        new{T, eltype(output_obs)}(components, to_abstractobservable(output), scope, layout)
+    function Widget{T}(components::OrderedDict{Symbol,Any}, output::Observable{S}, scope, layout) where {T,S}
+        new{T,S}(components, output, scope, layout)
     end
+end
+
+function Widget{T}(components::OrderedDict{Symbol,Any};
+    output = Observable{Any}(nothing),
+    scope = nothing,
+    layout = defaultlayout(get_backend())
+) where {T}
+    output_obs = to_abstractobservable(output)
+    Widget{T}(components, output_obs, scope, layout)
 end
 
 Widget{T}(components; kwargs...) where {T} = Widget{T}(OrderedDict{Symbol, Any}(Symbol(key) => val for (key, val) in components); kwargs...)
 
 Widget{T}(; components = OrderedDict{Symbol, Any}(), kwargs...) where {T} = Widget{T}(components; kwargs...)
 
-function Widget{T}(w::Widget; kwargs...) where {T}
-    dict = Dict{Symbol, Any}(kwargs)
-    for field in fieldnames(Widget)
-        get!(dict, field, getfield(w, field))
-    end
-    Widget{T}(; dict...)
+function Widget{T}(w::Widget; 
+    components=w.components, output=w.output, scope=w.scope, layout=w.layout, kw...
+) where {T}
+    Widget{T}(; components, output, scope, layout, kw...)
 end
 
 Widget(w::Widget{T}; kwargs...) where {T} = Widget{T}(w; kwargs...)

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -17,7 +17,7 @@ function Widget{T}(components::OrderedDict{Symbol,Any};
     scope = nothing,
     layout = defaultlayout(get_backend())
 ) where {T}
-    output_obs = to_abstractobservable(output)
+    output_obs = output isa AbstractObservable ? observe(output) : Observable(output)
     Widget{T}(components, output_obs, scope, layout)
 end
 

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -28,7 +28,7 @@ Widget{T}(; components = OrderedDict{Symbol, Any}(), kwargs...) where {T} = Widg
 function Widget{T}(w::Widget; 
     components=w.components, output=w.output, scope=w.scope, layout=w.layout, kw...
 ) where {T}
-    Widget{T}(; components, output, scope, layout, kw...)
+    Widget{T}(; components=components, output=output, scope=scope, layout=layout, kw...)
 end
 
 Widget(w::Widget{T}; kwargs...) where {T} = Widget{T}(w; kwargs...)


### PR DESCRIPTION
This PR aims to improve the load time of widgets.

TTF `Interact.slider(1:10)` is currently 15 seconds on my machine, after this PR -and the AssetRegistry PR- it is down to ~~5~~ 3. 

Hopefully it can be 1 second or less.

There are some problems with the design of AssetRegistry.jl and Wigets.jl that exacerbate the current load time.

First, using JSON3 instead of JSON in AssetRegistryjl is a huge improvement for all widgets - `slider(1:10)` in about 7 seconds.

https://github.com/JuliaGizmos/AssetRegistry.jl/pull/15

~~Second, because backends/themes are passed to all methods in InteractBase, but they are stored in a type unstable `Vector`, type instability propagates everywhere. Using the type of `AbstractBackend` and `WidgetTheme` instead of the constructed backend/theme means most methods wont specialise unless we specifically need them to, and the vector is `Vector{Type}`. This combined with fixing the type stability of various uses of `Dict` brings `slider` in InteractBase.jl down to 5 seconds, and closer to full type stability.~~ This change is remeoved so as not to be so breaking, and removing most of the unstable `gettheme` calls in InteractBase comes close anyway.

~~The last (I think) major problem is that the eltype of observables is known from the passed in range (e.g. `Int64` above) but it's lost, and has to be detected again in an unstable way in the  `Widget` constructor. We should as much as possible propagate those types throughout. Is there a reason it is detected again from `output_obs` ?~~


~~This will be a breaking change, and needs companion PRs in at least InteractBase.jl and Interact.jl. I'm writing all of these simultaneously, as making the whole ecosytem faster is the goal.~~

~~Edit: moving to always passing the eltype parameter `S` to `Widget{T,S}` brings the TTFS down to 3 seconds !! This also seems to be backwards compatible, just using one type parameter or passing `nothing` as the second type parameter triggers the original behaviour.~~

This was actually solvable with a few tweaks to the constructor methods to keep type stability, and is no longer breaking.

Much of the remaining performance improvments seem to be in WebIO.jl